### PR TITLE
feat(client): pass arguments to the flow language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,28 @@
     "type": "git",
     "url": "https://github.com/jbachhardie/vscode-flow-ls.git"
   },
-  "categories": ["Other"],
-  "activationEvents": ["onLanguage:javascript", "onLanguage:javascriptreact"],
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onLanguage:javascript",
+    "onLanguage:javascriptreact"
+  ],
   "main": "./out/src/extension",
+  "contributes": {
+    "configuration": {
+      "properties": {
+        "flow.lsArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Arguments to pass to the flow-language-server"
+        }
+      }
+    }
+  },
   "scripts": {
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -25,13 +25,20 @@
   "contributes": {
     "configuration": {
       "properties": {
-        "flow.lsArgs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "description": "Arguments to pass to the flow-language-server"
+        "flow.flowPath": {
+          "type": ["string", "null"],
+          "default": null,
+          "description": "An absolute path to a specific flow binary to use for the server"
+        },
+        "flow.autoDownloadFlow": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically download and manage flow binaries"
+        },
+        "flow.tryFlowBin": {
+          "type": "boolean",
+          "default": false,
+          "description": "Attempt to use flow-bin inside the $PROJECT_ROOT's node_modules directory"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,8 +59,14 @@ export function activate(context: ExtensionContext) {
     path.join('node_modules', 'flow-language-server', 'lib', 'bin', 'cli.js')
   )
   const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] }
-  const args = <string[]>workspace.getConfiguration("flow").get('lsArgs');
-  
+  const config = workspace.getConfiguration('flow')
+  const flowPath = config.get('flowPath') as string
+  const args = [
+    flowPath === null ? undefined : `--flow-path=${flowPath}`,
+    `--try-flow-bin=${config.get('tryFlowBin')}`,
+    `--no-auto-download=${!config.get('autoDownloadFlow')}`
+  ]
+
   const serverOptions: ServerOptions = {
     run: {
       module: serverModule,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,14 +59,18 @@ export function activate(context: ExtensionContext) {
     path.join('node_modules', 'flow-language-server', 'lib', 'bin', 'cli.js')
   )
   const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] }
+  const args = <string[]>workspace.getConfiguration("flow").get('lsArgs');
+  
   const serverOptions: ServerOptions = {
     run: {
       module: serverModule,
+      args,
       transport: TransportKind.ipc
     },
     debug: {
       module: serverModule,
       transport: TransportKind.ipc,
+      args,
       options: debugOptions
     }
   }


### PR DESCRIPTION
- Let users specify if they want the LSP to try loading
  the flow-bin from the local node_modules folder

Closes #3